### PR TITLE
update esprima-fb to 15001.1.0-dev-harmony-fb

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "codemirror": "^5.1.0",
     "escodegen": "^1.4.1",
-    "esprima-fb": "^14001.1.0-dev-harmony-fb",
+    "esprima-fb": "^15001.1.0-dev-harmony-fb",
     "keypress": "git://github.com/dmauro/Keypress",
     "pubsub-js": "^1.4.2",
     "react": "^0.12.1",


### PR DESCRIPTION
Flow's `import typeof ...` syntax was previously unsupported in `14001.1.0-dev-harmony-fb`. `15001.1.0-dev-harmony-fb` supports it.

Tested with a few random files, nothing seemed obviously broken.