### PR TITLE
`console.error` any transform errors

### DIFF
--- a/src/TransformOutput.js
+++ b/src/TransformOutput.js
@@ -38,7 +38,10 @@ export default class TransformOutput extends React.Component {
       }
       this.transform(nextProps).then(
         result => this.setState({result, error: null}),
-        error => this.setState({error})
+        error => {
+          console.error(error);
+          this.setState({error});
+        }
       );
     }
   }


### PR DESCRIPTION
Sometimes you get super cryptic error messages in the transform output panel, like `false !== true`, but if you break on errors the actual error object has good better info. This change logs these errors to the console so you can get better stack traces + jump to where the error is happening to investigate. The `console.clear` removes them when the change starts working so it doesn't spam to much.