### PR TITLE
add babel-eslint parser, using acorn-to-esprima pacakge for smaller bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The JavaScript AST explorer provides
 - [acorn][]
 - [babylon][]
 - [recast][]
+- [shift][]
+- [babel-eslint][]
 
 to parse the code. Depending on the parser settings, it not only supports ES5
 but also
@@ -21,7 +23,7 @@ but also
 
 Since future syntax is supported, the JavaScript AST explorer is a useful tool
 for developers who want to create AST transforms.
-In fact, [jscodeshift][] and [babel][] are included so you can prototype 
+In fact, [jscodeshift][] and [babel][] are included so you can prototype
 codemodding scripts and babel plugins.
 
 ### Features
@@ -46,6 +48,8 @@ corresponding AST node (or its ancestors of it isn't expanded):
 [espree]: https://github.com/eslint/espree
 [acorn]: https://github.com/marijnh/acorn
 [recast]: https://github.com/benjamn/recast
+[shift]: https://github.com/shapesecurity/shift-parser-js
+[babel-eslint]: https://github.com/babel/babel-eslint
 [jscodeshift]: https://github.com/facebook/jscodeshift
 [escodegen]: https://github.com/estools/escodegen
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "acorn": "^2.3.0",
+    "acorn-to-esprima": "^1.0.2",
     "babel-core": "^5.7.3",
     "babel-runtime": "^5.8.19",
     "babylon": "^5.8.22",

--- a/partition.json
+++ b/partition.json
@@ -1,7 +1,7 @@
 {
   "dist/app.js": ["./src/app"],
   "dist/parsers/acorn.js": ["acorn"],
-  "dist/parsers/babel.js": ["babylon", "babel-core"],
+  "dist/parsers/babel.js": ["babylon", "babel-core", "acorn-to-esprima"],
   "dist/parsers/esprima.js": ["esprima"],
   "dist/parsers/espree.js": ["espree"],
   "dist/parsers/recast.js": ["recast"],

--- a/src/parsers/babel-eslint.js
+++ b/src/parsers/babel-eslint.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import pkg from 'acorn-to-esprima/package.json';
+import loadAndExecute from './utils/loadAndExecute';
+
+const ID = 'acorn-to-esprima';
+const name = 'babel-eslint';
+
+export default {
+  id: ID,
+  displayName: name,
+  version: pkg.version,
+  homepage: pkg.homepage,
+
+  parse(code) {
+    return loadAndExecute(
+      ['acorn-to-esprima', 'babel-core'],
+      (acornToEsprima, {acorn, traverse, parse}) => {
+        const opts = {
+          locations: true,
+          ranges: true
+        };
+
+        const comments = opts.onComment = [];
+        const tokens = opts.onToken = [];
+
+        let ast;
+        try {
+          ast = parse(code, opts);
+        } catch (err) {
+          throw err;
+        }
+
+        ast.tokens = acornToEsprima.toTokens(tokens, acorn.tokTypes);
+        acornToEsprima.convertComments(comments);
+        ast.comments = comments;
+        acornToEsprima.attachComments(ast, comments, ast.tokens);
+        acornToEsprima.toAST(ast, traverse);
+
+        // remvove out node._paths
+        traverse(ast, {
+          noScope: true,
+          exit: function (node) {
+            if (node._paths) {
+              delete node._paths;
+            }
+          }
+        });
+        delete ast._paths;
+
+        return ast;
+      }
+    );
+  },
+
+  nodeToRange(node) {
+    if (typeof node.start !== 'undefined') {
+      return [node.start, node.end];
+    }
+  }
+};

--- a/src/parsers/index.js
+++ b/src/parsers/index.js
@@ -3,6 +3,7 @@ import espree from './espree';
 import acorn from './acorn';
 import babylon from './babylon';
 import recast from './recast';
+import babelEslint from './babel-eslint';
 
 export var parsers = [
   esprima,
@@ -10,6 +11,7 @@ export var parsers = [
   acorn,
   babylon,
   recast,
+  babelEslint
 ];
 
 export function getDefaultParser() {


### PR DESCRIPTION
Fixes #20 

Am I supposed to commit the `dist/` files as well? I removed them for now.

![screen shot 2015-08-24 at 2 27 10 pm](https://cloud.githubusercontent.com/assets/588473/9448731/4136eeb0-4a6c-11e5-8f8c-709c3ff63350.png)

I don't know if we want to filter out the `_paths` property or not