### PR TITLE
Guard against infinite loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "escodegen": "^1.4.1",
     "espree": "^2.2.4",
     "esprima": "^2.5",
+    "halting-problem": "^1.0.1",
     "jscodeshift": "^0.3",
     "keypress": "git://github.com/dmauro/Keypress",
     "pubsub-js": "^1.4.2",

--- a/src/transformers/babel.js
+++ b/src/transformers/babel.js
@@ -12,7 +12,7 @@ const options = {
   stage: 0,
 };
 
-function transform({transformCode, code}) {
+function transform(transformCode, code) {
   return new Promise((resolve, reject) => {
     loadjs(['babel-core'], babel => {
       try {

--- a/src/transformers/jscodeshift.js
+++ b/src/transformers/jscodeshift.js
@@ -8,7 +8,7 @@ const ID = 'jscodeshift';
 const defaultTransform =
   fs.readFileSync(__dirname + '/transformJscodeshift.txt', 'utf8');
 
-function transform({transformCode, code}) {
+function transform(transformCode, code) {
   return new Promise((resolve, reject) => {
     loadjs(['babel-core', 'jscodeshift'], (babel, jscodeshift) => {
       try {


### PR DESCRIPTION
This guards against infinite loops using the halting-problem module.

It catches simple cases like the following statically:

```js
export default function ({Plugin, types: t}) {
  return new Plugin('ast-transform', {
    visitor: {
      Identifier(node) {
        var n = 100;
        while (true) n++;
        return t.identifier(node.name.split('').reverse().join(''));
      }
    }
  });
}
```

results in

> while statement on line 6 has a constant test.  Either it is always `false` (making the statement redundant) or it is an infinite loop.

It can catch more subtle infinite loops like the following by checking for a timeout (of say 5 seconds) in all loops.  In this case it will just give you a message of "Infinite loop detected on line 6"

```js
export default function ({Plugin, types: t}) {
  return new Plugin('ast-transform', {
    visitor: {
      Identifier(node) {
        var n = 100;
        while (n > 0) n++;
        return t.identifier(node.name.split('').reverse().join(''));
      }
    }
  });
}
```