### PR TITLE
Fix method Set uses for membership

### DIFF
--- a/src/getFocusPath.js
+++ b/src/getFocusPath.js
@@ -32,7 +32,7 @@ export default function getFocusPath(node, pos, parser, path) {
     if (
       prop !== 'range' &&
       prop !== 'loc' &&
-      !ignoreProperties.contains(prop) &&
+      !ignoreProperties.has(prop) &&
       node[prop] &&
       typeof node[prop] === 'object'
     ) {


### PR DESCRIPTION
Set uses `has` not `contains` (see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has).

It looks to be related to change: https://github.com/fkling/esprima_ast_explorer/commit/4ebc1fb119452479d8623c0085cefb9847e2ac0f#diff-88541fdf6f0855d0c9f2f9c3a51c48c2R35.